### PR TITLE
Correção Live SDK Android

### DIFF
--- a/sambaplayersdk/src/main/java/com/sambatech/player/SambaPlayer.java
+++ b/sambaplayersdk/src/main/java/com/sambatech/player/SambaPlayer.java
@@ -872,9 +872,9 @@ public class SambaPlayer extends FrameLayout {
         switch (media.type.toLowerCase()) {
             case "hls":
                 if(media.clientId == 3170) {
-                    playerMediaSourceInterface = new PlayerMediaSourceHLS(playerInstanceDefault, url, true);
+                    playerMediaSourceInterface = new PlayerMediaSourceHLS(playerInstanceDefault, url, true, media.isLive);
                 } else {
-                    playerMediaSourceInterface = new PlayerMediaSourceHLS(playerInstanceDefault, url, false);
+                    playerMediaSourceInterface = new PlayerMediaSourceHLS(playerInstanceDefault, url, false, media.isLive);
                 }
                 break;
             case "dash":

--- a/sambaplayersdk/src/main/java/com/sambatech/player/mediasource/PlayerMediaSource.java
+++ b/sambaplayersdk/src/main/java/com/sambatech/player/mediasource/PlayerMediaSource.java
@@ -44,6 +44,7 @@ public class PlayerMediaSource {
     protected Boolean enablePeer5;
     protected MediaSource mediaSource;
     protected AdsLoader adsLoader;
+    protected Boolean isLive;
 
     protected PlayerMediaSource(@NonNull PlayerInstanceDefault playerInstanceDefault) {
         this.playerInstanceDefault = playerInstanceDefault;
@@ -71,6 +72,14 @@ public class PlayerMediaSource {
 
     public MediaSource getMediaSource() {
         return mediaSource;
+    }
+
+    public Boolean getIsLive() {
+        return this.isLive;
+    }
+
+    public void setIsLive(Boolean isLive) {
+        this.isLive = isLive;
     }
 
     private MappingTrackSelector.MappedTrackInfo getMappedTrackInfo() {

--- a/sambaplayersdk/src/main/java/com/sambatech/player/mediasource/PlayerMediaSourceHLS.java
+++ b/sambaplayersdk/src/main/java/com/sambatech/player/mediasource/PlayerMediaSourceHLS.java
@@ -22,8 +22,9 @@ public class PlayerMediaSourceHLS extends PlayerMediaSource implements PlayerMed
         super.setUrl(url);
         Uri uri = Uri.parse(url);
         MediaSource mediaSource;
+        boolean hasDrm = url.contains("/vodd-sd/");
 
-        if(this.getEnablePeer5()) {
+        if(this.getEnablePeer5() && !hasDrm) {
             String peer5Url = Peer5Sdk.getPeer5StreamUrl(url);
             Uri peer5Uri = Uri.parse(peer5Url);
 

--- a/sambaplayersdk/src/main/java/com/sambatech/player/mediasource/PlayerMediaSourceHLS.java
+++ b/sambaplayersdk/src/main/java/com/sambatech/player/mediasource/PlayerMediaSourceHLS.java
@@ -10,10 +10,10 @@ import com.peer5.sdk.Peer5Sdk;
 
 public class PlayerMediaSourceHLS extends PlayerMediaSource implements PlayerMediaSourceInterface {
 
-    public PlayerMediaSourceHLS(PlayerInstanceDefault playerInstanceDefault, String url,
-                                Boolean enablePeer5) {
+    public PlayerMediaSourceHLS(PlayerInstanceDefault playerInstanceDefault, String url, Boolean enablePeer5, boolean isLive) {
         super(playerInstanceDefault);
         this.setEnablePeer5(enablePeer5);
+        this.setIsLive(isLive);
         this.setUrl(url);
     }
 
@@ -31,7 +31,7 @@ public class PlayerMediaSourceHLS extends PlayerMediaSource implements PlayerMed
             uri = peer5Uri;
         }
 
-        if (SambaDownloadManager.getInstance().isConfigured()) {
+        if (!this.getIsLive() && SambaDownloadManager.getInstance().isConfigured()) {
             mediaSource = new HlsMediaSource.Factory(SambaDownloadManager.getInstance()
                     .buildDataSourceFactory())
                     .setPlaylistParserFactory(

--- a/sample/src/main/java/com/sambatech/sample/activities/MainActivity.java
+++ b/sample/src/main/java/com/sambatech/sample/activities/MainActivity.java
@@ -303,6 +303,16 @@ public class MainActivity extends AppCompatActivity {
 		mediaInfo11.setControlsEnabled(true);
 		mediaInfo11.setAutoPlay(true);
 
+		MediaInfo mediaInfo13 = new MediaInfo();
+
+		mediaInfo13.setTitle("Live NTI");
+		mediaInfo13.setProjectHash("7308d46a10eb5bef20e29516ca918f65");
+		mediaInfo13.setId("4b0b02faa183575a0fc9cac5108fae8d");
+		mediaInfo13.setEnvironment(SambaMediaRequest.Environment.PROD);
+		mediaInfo13.setLiveChannelId("2a5e02638bd35f735f1319c90772c103");
+		mediaInfo13.setControlsEnabled(true);
+		mediaInfo13.setAutoPlay(true);
+
 		mediaInfoList.add(mediaInfo);
         mediaInfoList.add(mediaInfo2);
         mediaInfoList.add(mediaInfo3);
@@ -314,6 +324,7 @@ public class MainActivity extends AppCompatActivity {
 		mediaInfoList.add(mediaInfo9);
 		mediaInfoList.add(mediaInfo10);
 		mediaInfoList.add(mediaInfo11);
+		mediaInfoList.add(mediaInfo13);
 
 		showMediaList(mediaInfoList);
 	}


### PR DESCRIPTION
## O que está sendo entregue

Existia um problema na em transmissões Live no SDK Android. O erro era replicável e seguia um padrão:

1. A Live começa a tocar
2. Toca exatamente 30 segundos
3. Fica carregando (trocando para URL de Backup)
4. Se estiver transmitindo para a URL de Backup ele toca mais 30 segundos e crasha
5. Se não estiver transmitindo para URL de Backup ele crasha

A raiz do problema era a implementação de Cache para download de conteúdo para assitir Offline. Esta funcionalidade entra em conflito com a forma que a Live toca o conteúdo. Assim, foi adicionado uma tratativa para não habilitar cache quando o contexto é live.

**Issue relacionada:** https://github.com/sambatech/webops/issues/4062