### PR TITLE
Deploy da nova versão

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - Suporte ao Samba Player Analytics
 - Suporte a advertising DFP
 - Player nativo do Android
+- Download de videos para assistir offline
 
 # SambaPlayer SDK (Android)
 
@@ -62,3 +63,13 @@ api.requestMedia(new SambaMediaRequest("34f07cf52fd85ccfc41a39bcf499e83b", "0632
 Para maiores informações, favor consultar nossa página [Wiki](https://github.com/sambatech/player_sdk_android/wiki).
 
 Para informações sobre o JavaDoc favor consultar a nossa página no [SambaDev](http://dev.sambatech.com/documentation/androidsdk/index.html)
+
+## Deploy
+
+1) Atualizar `versionName` no arquivo `sambaplayersdk/build.gradle` subindo a versão.
+
+2) Após o merge em master, gerar uma release com a nova versão
+
+3) Reexecutar o workflow de deploy para publicar no Bintray
+
+**OBS:** É necessário reexecutar o workflow porque a geração da release e publicação no GitHub não está automatizada circleci.

--- a/sambaplayersdk/build.gradle
+++ b/sambaplayersdk/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 17
         targetSdkVersion 28
         versionCode 41
-        versionName "v0.14.3-beta"
+        versionName "v0.14.5-beta"
     }
 
     compileOptions {


### PR DESCRIPTION
Forçando deploy da nova versão do SDK para o Bintray, pois o que foi entregue no PR https://github.com/sambatech/player_sdk_android/pull/86 não foi disponibilizado via nova versão do SDK.