### PR TITLE
Deploy v0.14.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,36 @@ Para informações sobre o JavaDoc favor consultar a nossa página no [SambaDev]
 3) Reexecutar o workflow de deploy para publicar no Bintray
 
 **OBS:** É necessário reexecutar o workflow porque a geração da release e publicação no GitHub não está automatizada circleci.
+
+#### Atenção :warning:
+
+O JFrog Bintray permite a inclusão de novas releases dentro de uma versão somente no período de 1 ano. Após este prazo, é necessário criar uma nova versão e atualizar no arquivo `assets/publish.sh`.
+
+Exemplo: Ao tentar publicar na versão **beta3** o seguinte erro é apresentado:
+
+```bash
+Info] Verifying repository maven exists...
+[Info] Verifying package sdk-android exists...
+[Info] Collecting files for upload...
+[Info] [Thread 1] Uploading artifact: sdk-android-0.14.5-beta.pom
+[Info] [Thread 0] Uploading artifact: sdk-android-0.14.5-beta.aar
+[Error] [Thread 1] Bintray response: 403 Forbidden
+Forbidden!
+[Error] [Thread 0] Bintray response: 403 Forbidden
+Forbidden!
+[Error] Failed uploading 2 artifacts.
+{
+  "status": "failure",
+  "totals": {
+    "success": 0,
+    "failure": 2
+  }
+}
+
+```
+
+Assim, na interface do JFrog Bintray é necessário criar uma nova versão.
+
+**Versão atual:** beta4
+**Data de criação:** 11/02/2020
+**Data de expiração:** 11/02/2021

--- a/assets/publish.sh
+++ b/assets/publish.sh
@@ -41,7 +41,7 @@ publish() {
 	# configuring repo client tool
 	./jfrog bt c --user=$repoUser --key=$repoApiKey --licenses=MIT
 	# uploading artifacts to repo
-	./jfrog bt u "$output/$2*" "sambatech/maven/sdk-android/beta3" "com/sambatech/player/$2/$v/" --publish=true --override=true
+	./jfrog bt u "$output/$2*" "sambatech/maven/sdk-android/beta4" "com/sambatech/player/$2/$v/" --publish=true --override=true
 
 	ret=$v
 }

--- a/sambaplayersdk/build.gradle
+++ b/sambaplayersdk/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 17
         targetSdkVersion 28
         versionCode 41
-        versionName "v0.14.5-beta"
+        versionName "v0.14.6-beta"
     }
 
     compileOptions {


### PR DESCRIPTION
Atualizando a versão de publicação no Bintray e forçando deploy da nova versão do SDK para o Bintray, pois o que foi entregue no PR https://github.com/sambatech/player_sdk_android/pull/86 não foi disponibilizado via nova versão do SDK.